### PR TITLE
Fix handling of ETF redirection in MarketWatchClient

### DIFF
--- a/marketwatch/__init__.py
+++ b/marketwatch/__init__.py
@@ -511,7 +511,7 @@ class MarketWatch:
         try:
             # Send a GET request to the MarketWatch URL for the given ticker
             url = f"https://www.marketwatch.com/investing/stock/{ticker.lower()}"
-            response = self.session.get(url)
+            response = self.session.get(url, follow_redirects=True)
             response.raise_for_status()  # Will raise HTTPError for 4XX/5XX status
 
             # Parse the HTML content using BeautifulSoup

--- a/test/test_ticker.py
+++ b/test/test_ticker.py
@@ -1,0 +1,38 @@
+import os
+from datetime import datetime
+
+import pytest
+
+from marketwatch import MarketWatch
+from marketwatch import MarketWatchException
+
+@pytest.fixture
+def authenticated_marketwatch():
+    username = os.environ.get("MARKETWATCH_USERNAME")
+    password = os.environ.get("MARKETWATCH_PASSWORD")
+    email = username
+    password = password
+    try:
+        return MarketWatch(email, password)
+    except MarketWatchException as e:
+        pytest.fail(f"Failed to authenticate: {e}")
+
+def test_get_price_stock(authenticated_marketwatch):
+    mw = authenticated_marketwatch
+    price = mw.get_price("MELI")
+    assert price is not None
+    assert isinstance(price, str)
+    assert "$" in price
+    assert "." in price
+    assert "MELI" in price
+    assert price != ""
+
+def test_get_price_fund(authenticated_marketwatch):
+    mw = authenticated_marketwatch
+    price = mw.get_price("AIQ")
+    assert price is not None
+    assert isinstance(price, str)
+    assert "$" in price
+    assert "." in price
+    assert "AIQ" in price
+    assert price != ""


### PR DESCRIPTION
### Fix handling of ETF redirection in MarketWatchClient

#### Description
This PR addresses an issue where requests to MarketWatch for ETF tickers were being redirected, causing the `get_price` method to fail. The solution includes:

- Allowing `httpx` to follow redirects automatically by setting `follow_redirects=True` in the `get` request.

#### Changes Made
- Updated the `get_price` method in `MarketWatchClient` to include `follow_redirects=True` in the GET request.

#### Testing
- Tested with various stock and ETF tickers to ensure correct redirection handling and price retrieval.
