### PR TITLE
feat: added get_ticker_info method with After Hours, Key Data and Pefomance Data

### DIFF
--- a/test/test_ticker.py
+++ b/test/test_ticker.py
@@ -33,3 +33,42 @@ def test_get_price_stock(authenticated_marketwatch):
     assert "." in price
     assert "AIQ" in price
     assert price != ""
+    
+def test_get_ticker_info(authenticated_marketwatch):
+    mw = authenticated_marketwatch
+    ticker_info = mw.get_ticker_info("MELI")
+    assert ticker_info is not None
+    assert isinstance(ticker_info, dict)
+    
+    # Check general fields
+    assert "ticker" in ticker_info
+    assert ticker_info["ticker"] == "MELI"
+    assert "price" in ticker_info
+    assert "change" in ticker_info
+    assert "percent_change" in ticker_info
+
+    # Check key data
+    assert "Day Range" in ticker_info
+    assert "Low" in ticker_info["Day Range"]
+    assert "High" in ticker_info["Day Range"]
+
+    assert "52 Week Range" in ticker_info
+    assert "Low" in ticker_info["52 Week Range"]
+    assert "High" in ticker_info["52 Week Range"]
+
+    # Optionally check for after_hours if it exists
+    if "after_hours" in ticker_info:
+        after_hours = ticker_info["after_hours"]
+        assert "price" in after_hours
+        assert "change" in after_hours
+        assert "percent_change" in after_hours
+
+    # Optionally check for performance data if it exists
+    if "performance" in ticker_info:
+        performance = ticker_info["performance"]
+        assert isinstance(performance, dict)
+        assert "5 Day" in performance
+        assert "1 Month" in performance
+        assert "3 Month" in performance
+        assert "YTD" in performance
+        assert "1 Year" in performance


### PR DESCRIPTION
### Description

This PR added the `get_ticker_info` method to provide more detailed information from MarketWatch.

**Key Changes:**
- Added functionality to parse 'After Hours' data including price, change, and percent change.
- Introduced parsing for 'Performance Data' covering multiple periods.
- Improved the returned dictionary to include new fields for better data representation.

### Testing

- Added a new pytest to validate the updated `get_ticker_info` method.
- The test ensures the method returns a dictionary with the expected structure and values.
- Sample output from the test:
  ```json
  {
    "ticker": "AIQ",
    "price": "$35.95",
    "change": "0.16",
    "percent_change": "0.45%",
    "Open": "$35.82",
    "Day Range": {"Low": "35.78", "High": "35.99"},
    "52 Week Range": {"Low": "25.39", "High": "35.99"},
    "Market Cap": "N/A",
    "Shares Outstanding": "57.12M",
    "Total Net Assets": "$1.834B",
    "Beta": "1.06",
    "NAV": "$35.68",
    "NAV Date": "06/17/24",
    "Net Expense Ratio": "0.68%",
    "Turnover %": "19%",
    "Yield": "0.14%",
    "Dividend": "$0.02",
    "Ex-Dividend Date": "Dec 28, 2023",
    "Average Volume": "607.51K",
    "after_hours": {"price": "35.90", "change": "-0.05", "percent_change": "-0.14%"}
  }
