### PR TITLE
Add get_holdings method to MarketWatchClient

### DIFF
--- a/test/test_ticker.py
+++ b/test/test_ticker.py
@@ -72,3 +72,50 @@ def test_get_ticker_info(authenticated_marketwatch):
         assert "3 Month" in performance
         assert "YTD" in performance
         assert "1 Year" in performance
+        
+def test_get_holdings_with_fund_ticker(authenticated_marketwatch):
+    mw = authenticated_marketwatch
+    ticker = "aiq"
+    result = mw.get_holdings(ticker)
+    
+    # Verificar que el resultado es un diccionario
+    assert result is not None
+    assert isinstance(result, dict)
+    
+    # Verificar campos generales
+    assert "ticker" in result
+    assert result["ticker"] == "AIQ"
+    assert "sector_allocation" in result
+    assert isinstance(result["sector_allocation"], dict)
+    assert "top_holdings" in result
+    assert isinstance(result["top_holdings"], list)
+    
+    # Verificar contenido de sector_allocation
+    sector_allocation = result["sector_allocation"]
+    assert "Technology" in sector_allocation
+    assert "Consumer Services" in sector_allocation
+    assert "Industrials" in sector_allocation
+    
+    # Verificar contenido de top_holdings
+    top_holdings = result["top_holdings"]
+    assert len(top_holdings) > 0
+    assert all(isinstance(item, dict) for item in top_holdings)
+    assert all("company" in item for item in top_holdings)
+    assert all("symbol" in item for item in top_holdings)
+    assert all("net_assets" in item for item in top_holdings)
+
+def test_get_holdings_with_stock_ticker(authenticated_marketwatch):
+    mw = authenticated_marketwatch
+    ticker = "meli"
+    
+    with pytest.raises(MarketWatchException) as exc_info:
+        mw.get_holdings(ticker)
+    
+    assert str(exc_info.value) == "Other error occurred: The ticker MELI is not a fund, it is a stock or index."
+    
+    ticker_index = "spx"
+    
+    with pytest.raises(MarketWatchException) as exc_info:
+        mw.get_holdings(ticker_index)
+        
+    assert str(exc_info.value) == "Other error occurred: The ticker SPX is not a fund, it is a stock or index."


### PR DESCRIPTION
Add get_holdings method to MarketWatchClient

- Implement get_holdings method to scrape fund holdings data from MarketWatch
- Method returns a dictionary with the following structure:
 `{
  'ticker': 'ONEQ',
  'sector_allocation': {
    'Technology': '58.15%',
    'Consumer Services': '15.25%',
    'Health Care': '6.02%',
    'Consumer Goods': '5.45%',
    'Industrials': '4.33%',
    'Financials': '3.85%',
    'Non Classified Equity': '3.07%',
    'Basic Materials': '1.24%',
    'Telecommunications': '0.81%',
    'Oil & Gas': '0.72%'
  },
  'top_holdings': [
    {
      'company': 'Microsoft Corp.',
      'symbol': 'MSFT',
      'net_assets': '11.38%'
    },
    {
      'company': 'Apple Inc.',
      'symbol': 'AAPL',
      'net_assets': '10.35%'
    },
    {
      'company': 'NVIDIA Corp.',
      'symbol': 'NVDA',
      'net_assets': '8.49%'
    },
    {
      'company': 'Amazon.com Inc.',
      'symbol': 'AMZN',
      'net_assets': '7.15%'
    },
    {
      'company': 'Alphabet Inc. Cl A',
      'symbol': 'GOOGL',
      'net_assets': '3.77%'
    },
    {
      'company': 'Meta Platforms Inc.',
      'symbol': 'META',
      'net_assets': '3.72%'
    },
    {
      'company': 'Alphabet Inc. Cl C',
      'symbol': 'GOOG',
      'net_assets': '3.67%'
    },
    {
      'company': 'Fidelity Securities Lending Cash Central Fund',
      'symbol': '',
      'net_assets': '3.20%'
    },
    {
      'company': 'Broadcom Inc.',
      'symbol': 'AVGO',
      'net_assets': '2.37%'
    },
    {
      'company': 'Tesla Inc.',
      'symbol': 'TSLA',
      'net_assets': '2.30%'
    }
  ]
}
`
- Raise exceptions for stock and index tickers by checking URL redirections
- Added unit tests to verify correct handling of fund, stock, and index tickers

![image](https://github.com/antoinebou12/marketwatch/assets/69726650/72433962-6374-4b43-af17-971cb66f01f4)

